### PR TITLE
Add image optimization to event images

### DIFF
--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -31,7 +31,7 @@
 		</div>
 
 		{{ if .File.Dir }}
-			{{ if (fileExists (print "./static/events/images/" .Params.eventNumber)) }}
+			{{ if (fileExists (print "./assets/events/images/" .Params.eventNumber)) }}
 				<br>
 				<a href="/events/{{ .Params.eventNumber }}/gallery/">تصاویر</a>
 				<br>
@@ -65,12 +65,18 @@
 		<div class="poster">
 			{{ if .File.Dir }}
 				{{ $basename := (print "/events/poster/" .Params.eventNumber "/") }}
-				{{ if (fileExists (print "./static" $basename)) }}
-					{{ range (readDir (print "./static" $basename )) }}
-						<a href="{{ $basename | relURL }}{{ .Name }}" target="_blank">
-							<img src="{{ $basename | relURL }}{{ .Name }}"/>
-							{{ index (split .Name ".") 0 }}
-						</a>
+				{{ if (fileExists (print "./assets" $basename)) }}
+					{{ range (readDir (print "./assets" $basename )) }}
+						{{$imageName := index (split .Name ".") 0}}
+						{{ with resources.Get (print ($basename | relURL) .Name) }}
+							<a href="{{ .RelPermalink }}" target="_blank">
+								{{ with .Resize "300x" }}
+									<img src="{{ .RelPermalink }}" height="150" />
+								{{ end }}
+
+								{{ $imageName }}
+							</a>
+						{{ end }}
 				
 					{{ end }}
 					

--- a/layouts/_default/gallery.html
+++ b/layouts/_default/gallery.html
@@ -13,13 +13,19 @@
 		<div class="gallery">
 			{{ if .File.Dir }}
 				{{ $basename := (print "/events/images/" .Params.eventNumber "/") }}
-				{{ if (fileExists (print "./static" $basename)) }}
-					{{ range (readDir (print "./static" $basename )) }}
+				{{ if (fileExists (print "./assets" $basename)) }}
+					{{ range (readDir (print "./assets" $basename )) }}
+						{{$imageName := index (split .Name ".") 0}}
 						<div class="gallery-column">
-							<a href="{{ $basename | relURL }}{{ .Name }}" target="_blank">
-								<img src="{{ $basename | relURL }}{{ .Name }}"/>
-								{{ index (split .Name ".") 0 }}
+							{{ with resources.Get (print ($basename | relURL) .Name) }}
+								<a href="{{ .RelPermalink }}" target="_blank">
+								{{ with .Resize "300x" }}
+									<img src="{{ .RelPermalink }}" height="150" />
+								{{ end }}
+
+								{{ $imageName }}
 							</a>
+							{{ end }}
 						</div>
 				
 					{{ end }}

--- a/layouts/_default/images.html
+++ b/layouts/_default/images.html
@@ -8,8 +8,8 @@
 
 		<ul class="posts">
 			{{ if .File.Dir }}
-				{{ if (fileExists (print "./static/events/images/")) }}
-					{{ range (readDir (print "./static/events/images")) }}
+				{{ if (fileExists (print "./assets/events/images/")) }}
+					{{ range (readDir (print "./assets/events/images")) }}
 						<li class="post-summary">
 							<a href="/events/{{.Name}}/gallery">جلسه {{partial "persianNumber.html" .Name}}</a>
 						</li>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -483,34 +483,45 @@ table th, table td {
 }
 
 .poster {
-    margin: 0 auto;
-    width: 200px;
+  margin: 0 auto;
+  width: 300px;
+}
+
+.gallery,
+.gallery * {
+  box-sizing: border-box;
 }
 
 .gallery {
-    display: flex;
-    flex-wrap: wrap;
-    padding: 0 4px;
-    text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  text-align: center;
+  margin-top: -8px;
+  margin-inline: -4px;
+  width: 100%;
 }
 
 .gallery-column {
-    flex: 25%;
+  flex: 0 0 auto;
+  width: 25%;
+  margin-top: 8px;
+  padding-inline: 4px;
 }
 
 .gallery-column img {
-    margin-top: 8px;
-    width: 100%;
+  margin-block: 8px;
+  width: 100%;
+  object-fit: cover;
 }
 
 @media screen and (max-width: 800px) {
-    .gallery-column {
-        flex: 50%;
-    }
+  .gallery-column {
+    width: 50%;
+  }
 }
 
 @media screen and (max-width: 600px) {
-    .gallery-column {
-        flex: 100%;
-    }
+  .gallery-column {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
This PR proposes image optimization for event images using [hugo builtin image processor](https://gohugo.io/content-management/image-processing/#resize) 

All down streams that are using this theme should:

- move the `static/events/` to `assets/events/`
- add `/resources` to `.gitignore`

example: https://github.com/birlug/birlug.github.io/pull/52